### PR TITLE
feat: display difference from expected month work hours through today

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,18 @@
       "name": "harvest-week",
       "title": "This Week",
       "description": "Get a glance of this week's submitted hours",
-      "mode": "view"
+      "mode": "view",
+      "preferences": [
+        {
+          "title": "Display Options",
+          "name": "displayExpectedHoursDiff",
+          "label": "Expected work hours difference",
+          "description": "Expected work hours is based on the number of work days from month start up to and including the current date. The difference is displayed next to the registered and total work hours in the navigation title.",
+          "type": "checkbox",
+          "default": true,
+          "required": false
+        }
+      ]
     }
   ],
   "preferences": [

--- a/raycast-env.d.ts
+++ b/raycast-env.d.ts
@@ -23,7 +23,10 @@ declare namespace Preferences {
   /** Preferences accessible in the `harvest-hours` command */
   export type HarvestHours = ExtensionPreferences & {}
   /** Preferences accessible in the `harvest-week` command */
-  export type HarvestWeek = ExtensionPreferences & {}
+  export type HarvestWeek = ExtensionPreferences & {
+  /** Display Options - Expected work hours is based on the number of work days from month start up to and including the current date. The difference is displayed next to the registered and total work hours in the navigation title. */
+  "displayExpectedHoursDiff"?: boolean
+}
 }
 
 declare namespace Arguments {

--- a/src/utils/workdays/index.ts
+++ b/src/utils/workdays/index.ts
@@ -9,6 +9,15 @@ export const getMonthlyTotal = (payDate: DateTime) => {
   return workDays.length * dailyWorkHours;
 };
 
+export const getTotalWorkHoursThroughDate = (date: DateTime) => {
+  return getWorkDaysInMonthThroughDate(date).length * dailyWorkHours;
+};
+
+export const getWorkDaysInMonthThroughDate = (date: DateTime) => {
+  const workDays = getWorkDaysInMonth(date);
+  return workDays.filter((d) => d.startOf("day") <= date.startOf("day"));
+};
+
 const getWorkDaysInMonth = (payDate: DateTime) => {
   return getWorkdaysInMonth(payDate.year, payDate.month);
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*",
+    "raycast-env.d.ts"
+  ],
   "compilerOptions": {
     "lib": ["es2021"],
     "module": "commonjs",


### PR DESCRIPTION
Calculates the expected work hours from month start and up to and including current date. The difference between this and the registered work hours is shown in the navigation title (see images)

This is useful for quickly seeing how many hours you need to work extra or take time off before the end of the month (assuming 100% work percentage).

The user can opt out of this feature via the command preferences.

#### 🔻 Deficit

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9a22331f-67be-4287-b00c-af720c7552c1" />

#### 🎯 À jour
> could have hidden the diff here, but this assures the user that the difference is checked
<img width="400" alt="image" src="https://github.com/user-attachments/assets/27a7e3a9-cf53-4ed7-aea3-db7ca85d857b" />

#### ❇️ Surplus

<img width="400" alt="image" src="https://github.com/user-attachments/assets/03735cef-4937-4d34-8e48-9a9bc50b83c6" />

#### ⚙️ Opt-out

<img width="303" alt="image" src="https://github.com/user-attachments/assets/077c8d23-7508-48da-b22c-83b2a5ff3b15" />
